### PR TITLE
Fix postgres' broken libldap and libicu deps

### DIFF
--- a/bitnami/postgresql/17/ubuntu-noble/Dockerfile
+++ b/bitnami/postgresql/17/ubuntu-noble/Dockerfile
@@ -16,7 +16,8 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
  ca-certificates curl libbsd0 libbz2-1.0 libedit2 libffi8 libgcc-s1 libgmp10 libgnutls30 libhogweed6 libicu74 libidn2-0 libldap2 liblz4-1 liblzma5 libmd0 libnettle8 libp11-kit0 libpcre3 libreadline8 libsasl2-2 libsqlite3-0 libssl3 libstdc++6 libtasn1-6 libtinfo6 libunistring5 libuuid1 libxml2 libxslt1.1 libzstd1 locales procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
@@ -40,6 +41,18 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
 RUN update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
     DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
 RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+
+RUN echo "deb http://archive.ubuntu.com/ubuntu jammy main universe" >> /etc/apt/sources.list && \
+    apt update && \
+    apt install -y libldap-2.5-0 && \
+    sed -i '/jammy/d' /etc/apt/sources.list && \
+    apt clean
+
+RUN echo "deb http://old-releases.ubuntu.com/ubuntu lunar main universe" >> /etc/apt/sources.list && \
+    apt update && \
+    apt install -y libicu72 && \
+    sed -i '/lunar/d' /etc/apt/sources.list && \
+    apt clean
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/postgresql/postunpack.sh


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Postgres was silently crashing out after updating to the `ubuntu:noble` base image. This turned out to be because of a shared library dependency mismatch:

```
$ ldd $(which postgres)
        linux-vdso.so.1 (0x00007ffec695e000)
        liblz4.so.1 => /lib/x86_64-linux-gnu/liblz4.so.1 (0x000079b265f44000)
        libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x000079b265d62000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x000079b265cb8000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x000079b2657a5000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x000079b265789000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000079b26569e000)
        libldap-2.5.so.0 => not found
        libicui18n.so.72 => not found
        libicuuc.so.72 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000079b26548c000)
        libicuuc.so.74 => /lib/x86_64-linux-gnu/libicuuc.so.74 (0x000079b26527d000)
        liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x000079b26524b000)
        /lib64/ld-linux-x86-64.so.2 (0x000079b2668f6000)
        libicudata.so.74 => /lib/x86_64-linux-gnu/libicudata.so.74 (0x000079b2634eb000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x000079b26326d000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000079b26323f000)
```

Neither of the required versions are available in the current `noble` `apt` repo, so this PR reaches back into `jammy` and `lunar` repos to install them.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
