### PR TITLE
Update keycloak JRE version to 21.0.8

### DIFF
--- a/bitnami/keycloak-config-cli/6/debian-12/Dockerfile
+++ b/bitnami/keycloak-config-cli/6/debian-12/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y ca-certificates curl procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
-      "jre-21.0.7-9-0-linux-${OS_ARCH}-debian-12" \
+      "jre-21.0.8-12-0-linux-${OS_ARCH}-debian-12" \
       "keycloak-config-cli-6.4.0-0-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \

--- a/bitnami/keycloak/26/debian-12/Dockerfile
+++ b/bitnami/keycloak/26/debian-12/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y ca-certificates curl krb5-user libaio1t
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "wait-for-port-1.0.8-15-linux-${OS_ARCH}-debian-12" \
-      "jre-21.0.7-9-0-linux-${OS_ARCH}-debian-12" \
+      "jre-21.0.8-12-0-linux-${OS_ARCH}-debian-12" \
       "keycloak-26.2.3-0-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \


### PR DESCRIPTION
This PR updates the JRE version in the `keycloak` container to address the following CVEs:

* [CVE-2025-50059](https://nvd.nist.gov/vuln/detail/CVE-2025-50059)
* [CVE-2025-50106](https://nvd.nist.gov/vuln/detail/CVE-2025-50106)
* [CVE-2025-30749](https://nvd.nist.gov/vuln/detail/CVE-2025-30749)
* [CVE-2025-30754](https://nvd.nist.gov/vuln/detail/CVE-2025-30754)

